### PR TITLE
Fix TechRequired for gas analyzer

### DIFF
--- a/GameData/SpaceDust/Parts/Scanning/spacedust-gas-analyzer-1.cfg
+++ b/GameData/SpaceDust/Parts/Scanning/spacedust-gas-analyzer-1.cfg
@@ -12,7 +12,7 @@ PART
 
 	scale = 1
 	node_attach = 0.108, 0.0, 0, 1.0, 0.0, 0,0
-	TechRequired = scanningTech
+	TechRequired = scienceTech
 	entryCost = 2900
 	cost = 1150
 	category = Science


### PR DESCRIPTION
Gas analyzer tech node was specified as scanningTech, but Scanning Tech's internal ID is scienceTech. This change allows the gas analyzer to be properly available in non-sandbox games.