### PR TITLE
Fix unreachable code preventing ModuleSpaceDustHarvester from reporting that it can't function.

### DIFF
--- a/Source/SpaceDust/Modules/ModuleSpaceDustHarvester.cs
+++ b/Source/SpaceDust/Modules/ModuleSpaceDustHarvester.cs
@@ -1,4 +1,4 @@
-﻿using KSP.Localization;
+ using KSP.Localization;
 using Smooth.Algebraics;
 using System;
 using System.Collections.Generic;
@@ -411,17 +411,16 @@ namespace SpaceDust
     }
     void DoFocusedHarvesting(double scale)
     {
-
-      if (HarvestType == HarvesterType.Atmosphere && part.vessel.atmDensity > 0d)
+      if (HarvestType == HarvesterType.Atmosphere && part.vessel.atmDensity <= 0d)
       {
-        if (part.vessel.atmDensity <= 0d)
-        {
           ScoopUI = Localizer.Format("#LOC_SpaceDust_ModuleSpaceDustHarvester_Field_Scoop_NeedsAtmo");
 
           Fields["ThermalUI"].guiActive = false;
           Fields["IntakeSpeed"].guiActive = false;
           return;
-        }
+      }
+      if (HarvestType == HarvesterType.Atmosphere && part.vessel.atmDensity > 0d)
+      {
         Vector3d worldVelocity = part.vessel.srf_velocity;
         double mach = part.vessel.mach;
 
@@ -468,18 +467,15 @@ namespace SpaceDust
           ScoopUI = Localizer.Format("#LOC_SpaceDust_ModuleSpaceDustHarvester_Field_Scoop_Resource_None");
       }
 
-
+      if (HarvestType == HarvesterType.Exosphere && part.vessel.atmDensity > 0d)
+      {
+        ScoopUI = Localizer.Format("#LOC_SpaceDust_ModuleSpaceDustHarvester_Field_Scoop_NeedsVacuum");
+        Fields["ThermalUI"].guiActive = false;
+        Fields["IntakeSpeed"].guiActive = false;
+        return;
+      }
       if (HarvestType == HarvesterType.Exosphere && part.vessel.atmDensity == 0d)
       {
-        if (part.vessel.atmDensity > 0d)
-        {
-          ScoopUI = Localizer.Format("#LOC_SpaceDust_ModuleSpaceDustHarvester_Field_Scoop_NeedsVacuum");
-          Fields["ThermalUI"].guiActive = false;
-          Fields["IntakeSpeed"].guiActive = false;
-          return;
-        }
-
-
         Vector3d worldVelocity = part.vessel.obt_velocity;
         Vector3 intakeVector;
         if (HarvestIntakeTransform == null)
@@ -544,3 +540,4 @@ namespace SpaceDust
 
 
 }
+


### PR DESCRIPTION
I noticed that atmospheric scoops in vacuum and vacuum scoops in atmosphere would still turn on, but say "no resources to harvest". It turns out that there is some unreachable code in here that is supposed to render an appropriate status message in these situations.