### PR TITLE
Removed duplicate divisions by density

### DIFF
--- a/Source/SpaceDust/Modules/ModuleSpaceDustHarvester.cs
+++ b/Source/SpaceDust/Modules/ModuleSpaceDustHarvester.cs
@@ -456,7 +456,7 @@ namespace SpaceDust
 
           if (resourceSample > resources[i].MinHarvestValue)
           {
-            double resAmt = resourceSample * intakeVolume * 1d / resources[i].density * resources[i].BaseEfficiency * scale;
+            double resAmt = resourceSample * intakeVolume * 1d * resources[i].BaseEfficiency * scale;
             if (ScoopUI != "")
               ScoopUI += "\n";
             ScoopUI += Localizer.Format("#LOC_SpaceDust_ModuleSpaceDustHarvester_Field_Scoop_Resource", resources[i].Name, resAmt.ToString("G5"));
@@ -512,7 +512,7 @@ namespace SpaceDust
             //  $"speedstatic {IntakeSpeedStatic}," +
             //  $"worldvel {worldVelocity.magnitude}");
 
-            double resAmt = resourceSample * intakeVolume * 1d / resources[i].density * resources[i].BaseEfficiency * scale;
+            double resAmt = resourceSample * intakeVolume * 1d * resources[i].BaseEfficiency * scale;
             if (ScoopUI != "")
               ScoopUI += "\n";
             ScoopUI += Localizer.Format("#LOC_SpaceDust_ModuleSpaceDustHarvester_Field_Scoop_Resource", resources[i].Name, resAmt.ToString("G3"));

--- a/Source/SpaceDust/Modules/ModuleSpaceDustScanner.cs
+++ b/Source/SpaceDust/Modules/ModuleSpaceDustScanner.cs
@@ -267,7 +267,7 @@ namespace SpaceDust
                     part.vessel.mainBody,
                     vessel.altitude + part.vessel.mainBody.Radius,
                     vessel.latitude,
-                    vessel.longitude) * 1d / resources[i].density;
+                    vessel.longitude) * 1d;
                   //Utils.Log($"{resources[i].Name} at {part.vessel.mainBody}, alt: {vessel.altitude} lat: {vessel.latitude}, lon: {vessel.longitude}, sample: {resourceSample}");
                   // This mod discovers all bands at the body
                   if (resources[i].DiscoverMode == DiscoverMode.SOI)


### PR DESCRIPTION
SampleResource [divides the resource quantity by its density](https://github.com/post-kerbin-mining-corporation/SpaceDust/blob/a5d59da55d7a9cd0dce1d34ac2937673950f5637/Source/SpaceDust/ResourceMap.cs#L98), converting from the t/m^3 that the .cfg files specify to the u/m^3 displayed in the toolbar in the map screen. But the scanner and harvester modules divide by density again, meaning that for very low-density resources like LqdHydrogen and Antimatter they pull in thousands of times more than the map screen toolbar's value implies.

I've fixed the double division. The map screen toolbar and the numbers given by scanners and harvesters should line up now.