### PR TITLE
Fixes to default values and comments

### DIFF
--- a/Source/SpaceDust/Modules/ModuleSpaceDustHarvester.cs
+++ b/Source/SpaceDust/Modules/ModuleSpaceDustHarvester.cs
@@ -18,8 +18,8 @@ namespace SpaceDust
     public string Name = "undefined";
     // The basic efficiency, applied at local V = 0
     public float BaseEfficiency;
-    public double MinHarvestValue = 0.0001d;
-    public double density = 0.05;
+    public double MinHarvestValue = 0.0001d;    // t/m^3 (0.08 atm)
+    public double density = 0.05;               // KSP resource mass (t/unit)
 
 
     public HarvestedResource() { }
@@ -59,12 +59,11 @@ namespace SpaceDust
     [KSPField(isPersistant = false)]
     public float IntakeSpeedStatic = 0f;
 
-    // The velocity to use when the intake is static
+    // The effective area of the intake
     [KSPField(isPersistant = false)]
     public float IntakeArea = 0f;
 
     // Maps how well the intake works as velocity increases. 0 = nothing, 1= baseEfficiency
-
     [KSPField(isPersistant = false)]
     public FloatCurve IntakeVelocityScale;
 
@@ -114,7 +113,7 @@ namespace SpaceDust
     [KSPField(isPersistant = false, guiActive = true, guiActiveEditor = false, guiName = "#LOC_SpaceDust_ModuleSpaceDustHarvester_Field_IntakeSpeed")]
     public string IntakeSpeed = "";
 
-    // UI field for showing sscoop status
+    // UI field for showing scoop status
     [KSPField(isPersistant = false, guiActive = true, guiActiveEditor = false, guiName = "#LOC_SpaceDust_ModuleSpaceDustHarvester_Field_Scoop")]
     public string ScoopUI = "";
 

--- a/Source/SpaceDust/Modules/ModuleSpaceDustScanner.cs
+++ b/Source/SpaceDust/Modules/ModuleSpaceDustScanner.cs
@@ -19,11 +19,11 @@ namespace SpaceDust
     [KSPField(isPersistant = false)]
     public float minResToLeave = 0.1f;
 
-    /// Am i enabled?
+    /// Does the scanner work in vacuum?
     [KSPField(isPersistant = false)]
     public bool ScanInSpace = true;
 
-    /// Am i enabled?
+    /// Does the scanner work in atmosphere?
     [KSPField(isPersistant = false)]
     public bool ScanInAtmosphere = true;
 

--- a/Source/SpaceDust/Modules/ModuleSpaceDustTelescope.cs
+++ b/Source/SpaceDust/Modules/ModuleSpaceDustTelescope.cs
@@ -60,7 +60,7 @@ namespace SpaceDust
     [KSPField(isPersistant = true)]
     public float CurrentPowerConsumption = 1f;
 
-    // Current cost to run the scanner
+    // Number of slots the telescope is equipped with
     [KSPField(isPersistant = true)]
     public int Slots = 2;
 
@@ -91,9 +91,9 @@ namespace SpaceDust
     [KSPField(isPersistant = false)]
     public double ObjectiveDiameter = 1.8d;
 
-    // Size of the lens
+    // Field of view (in radians)
     [KSPField(isPersistant = false)]
-    public double FieldOfView = 1.8d;
+    public double FieldOfView = 0.001d;     // 3.4 arcminutes
 
     [KSPEvent(guiActive = true, guiActiveEditor = true, guiName = "#LOC_SpaceDust_ModuleSpaceDustTelescope_Event_EnableTelescope", active = true)]
     public void EnableTelescope()

--- a/Source/SpaceDust/Modules/ScannedResource.cs
+++ b/Source/SpaceDust/Modules/ScannedResource.cs
@@ -21,10 +21,10 @@ namespace SpaceDust
     public string Name = "";
     public DiscoverMode DiscoverMode;
     public DiscoverMode IdentifyMode;
-    public double LocalThreshold = 0.01;
+    public double LocalThreshold = 1e-5;        // t/m^3 (0.008 atm)
     public double DiscoverRange = 70000;
     public double IdentifyRange = 30000;
-    public double density = 0.05;
+    public double density = 0.05;               // KSP resource mass (t/unit)
 
     private const string DISCOVER_MODE_PARAMETER_NAME = "DiscoverMode";
     private const string IDENTIFY_MODE_PARAMETER_NAME = "IdentifyMode";

--- a/Source/SpaceDust/SpaceDustInstrument.cs
+++ b/Source/SpaceDust/SpaceDustInstrument.cs
@@ -47,7 +47,7 @@ namespace SpaceDust
       // Configure the default curve
       AtmosphereEffect = new FloatCurve();
       AtmosphereEffect.Add(0f, 1f);
-      AtmosphereEffect.Add(70000f, 5f);
+      AtmosphereEffect.Add(70000f, 0.5f);
       AtmosphereEffect.Add(500000f, 0f);
       ConfigNode floatCurveNode = new ConfigNode();
       if (node.TryGetNode(ATMOSPHERE_PARAMETER_NAME, ref floatCurveNode))


### PR DESCRIPTION
This PR fixes a number of typos and copy-paste errors I came across while trying to understand the code. They include a bug that makes it effectively impossible for local scanners to operate unless they override `LocalThreshold`.